### PR TITLE
[UPGRADE] Correct ref to wrong gem

### DIFF
--- a/acts_as_versioned.gemspec
+++ b/acts_as_versioned.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.homepage      = 'http://github.com/Decisiv/acts_as_versioned/'
   s.summary       = 'ActiveRecord plugin for versioning your models.'
   s.description   = 'ActiveRecord plugin for versioning your models. For Rails 3.'
-  s.files         = `git ls-files`.split("\n") - ["attr_stripper.gemspec"]
+  s.files         = `git ls-files`.split("\n") - ["acts_as_versioned.gemspec"]
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ['lib']


### PR DESCRIPTION
In the gemspec the gemspec file itself was referencing `attr_stripper`